### PR TITLE
Add option to disable Consul service discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coverage/
 
 # OS X generated files and folders
 .DS_Store
+
+package-lock.json

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -16,17 +16,23 @@ const lookup = function (hostname, callback) {
     throw new Error('Callback is missing.');
   }
 
-  isLocal(hostname, (err, isLocalhost) => {
-    if (err) {
-      return callback(err);
-    }
+  const serviceDiscovery = getenv('SERVICE_DISCOVERY', 'consul');
 
-    if (isLocalhost && useLocalhost) {
-      return callback(null, '127.0.0.1');
-    }
+  if (serviceDiscovery === 'consul') {
+    isLocal(hostname, (err, isLocalhost) => {
+      if (err) {
+        return callback(err);
+      }
 
-    consul.lookup(hostname, callback);
-  });
+      if (isLocalhost && useLocalhost) {
+        return callback(null, '127.0.0.1');
+      }
+
+      consul.lookup(hostname, callback);
+    });
+  } else {
+    return callback(null, hostname);
+  }
 };
 
 module.exports = lookup;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "assertthat": "0.10.3",
     "eslint-config-seal": "0.0.9",
     "nock": "9.0.14",
-    "nodeenv": "0.2.1",
+    "nodeenv": "1.0.0",
     "proxyquire": "1.8.0",
     "roboter": "0.15.4",
     "roboter-server": "0.15.4"

--- a/test/getCiphersTest.js
+++ b/test/getCiphersTest.js
@@ -17,11 +17,11 @@ suite('getCiphers', () => {
   });
 
   test('returns the contents of the environment variable TLS_CIPHERS.', (done) => {
-    nodeenv('TLS_CIPHERS', 'foobar', (restore) => {
-      assert.that(getCiphers()).is.equalTo('foobar');
-      restore();
-      done();
-    });
+    const restore = nodeenv('TLS_CIPHERS', 'foobar');
+
+    assert.that(getCiphers()).is.equalTo('foobar');
+    restore();
+    done();
   });
 
   // Note: Depends on test above!

--- a/test/getProtocolTest.js
+++ b/test/getProtocolTest.js
@@ -47,63 +47,63 @@ suite('getProtocol', () => {
 
   suite('with TLS_UNPROTECTED set to \'none\'', () => {
     test('returns \'https\'.', (done) => {
-      nodeenv('TLS_UNPROTECTED', 'none', (restore) => {
-        getProtocol({ name: 'foo.node.dc1.consul' }, (err, protocol) => {
-          assert.that(err).is.falsy();
-          assert.that(protocol).is.equalTo('https');
-          restore();
-          done();
-        });
+      const restore = nodeenv('TLS_UNPROTECTED', 'none');
+
+      getProtocol({ name: 'foo.node.dc1.consul' }, (err, protocol) => {
+        assert.that(err).is.falsy();
+        assert.that(protocol).is.equalTo('https');
+        restore();
+        done();
       });
     });
   });
 
   suite('with TLS_UNPROTECTED set to \'world\'', () => {
     test('returns \'http\'.', (done) => {
-      nodeenv('TLS_UNPROTECTED', 'world', (restore) => {
-        getProtocol({ name: 'foo.node.dc1.consul' }, (err, protocol) => {
-          assert.that(err).is.falsy();
-          assert.that(protocol).is.equalTo('http');
-          restore();
-          done();
-        });
+      const restore = nodeenv('TLS_UNPROTECTED', 'world');
+
+      getProtocol({ name: 'foo.node.dc1.consul' }, (err, protocol) => {
+        assert.that(err).is.falsy();
+        assert.that(protocol).is.equalTo('http');
+        restore();
+        done();
       });
     });
   });
 
   suite('with TLS_UNPROTECTED set to \'loopback\'', () => {
     test('returns \'http\' if target is the same host.', (done) => {
-      nodeenv('TLS_UNPROTECTED', 'loopback', (restore) => {
-        getProtocol({ name: 'foo.node.dc1.consul' }, (err, protocol) => {
-          assert.that(err).is.falsy();
-          assert.that(protocol).is.equalTo('http');
-          restore();
-          done();
-        });
+      const restore = nodeenv('TLS_UNPROTECTED', 'loopback');
+
+      getProtocol({ name: 'foo.node.dc1.consul' }, (err, protocol) => {
+        assert.that(err).is.falsy();
+        assert.that(protocol).is.equalTo('http');
+        restore();
+        done();
       });
     });
 
     test('returns \'https\' if target is another host.', (done) => {
-      nodeenv('TLS_UNPROTECTED', 'loopback', (restore) => {
-        getProtocol({ name: 'other-host.node.dc1.consul' }, (err, protocol) => {
-          assert.that(err).is.falsy();
-          assert.that(protocol).is.equalTo('https');
-          restore();
-          done();
-        });
+      const restore = nodeenv('TLS_UNPROTECTED', 'loopback');
+
+      getProtocol({ name: 'other-host.node.dc1.consul' }, (err, protocol) => {
+        assert.that(err).is.falsy();
+        assert.that(protocol).is.equalTo('https');
+        restore();
+        done();
       });
     });
   });
 
   suite('with TLS_UNPROTECTED set to an unknown value', () => {
     test('returns an error.', (done) => {
-      nodeenv('TLS_UNPROTECTED', 'foobar', (restore) => {
-        getProtocol({ name: 'foo.node.dc1.consul' }, (err) => {
-          assert.that(err).is.not.falsy();
-          assert.that(err.message).is.equalTo('TLS_UNPROTECTED invalid.');
-          restore();
-          done();
-        });
+      const restore = nodeenv('TLS_UNPROTECTED', 'foobar');
+
+      getProtocol({ name: 'foo.node.dc1.consul' }, (err) => {
+        assert.that(err).is.not.falsy();
+        assert.that(err.message).is.equalTo('TLS_UNPROTECTED invalid.');
+        restore();
+        done();
       });
     });
   });

--- a/test/lookupTest.js
+++ b/test/lookupTest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assertthat');
+const nodeenv = require('nodeenv');
 const proxyquire = require('proxyquire');
 
 let errLookup;
@@ -81,6 +82,19 @@ suite('lookup', () => {
       assert.that(err).is.not.falsy();
       assert.that(err.message).is.equalTo('foobar');
       done();
+    });
+  });
+
+  suite('cloud service discovery', () => {
+    test('directly uses service name.', (done) => {
+      const restore = nodeenv('SERVICE_DISCOVERY', 'cloud');
+
+      lookup('bodyscanner', (err, ip) => {
+        assert.that(err).is.falsy();
+        assert.that(ip).is.equalTo('bodyscanner');
+        restore();
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
For cloud environments, disable the Consul service discovery by setting env `SERVICE_DISCOVERY=cloud`.
